### PR TITLE
Updated the new executive committee for the AMS grad chapter

### DIFF
--- a/AMS_chapter/index.md
+++ b/AMS_chapter/index.md
@@ -18,11 +18,11 @@ To become a member and enjoy extra perks, such as being added to the chapter mai
 
 The University of Virginia AMS graduate student chapter executive committee consists of:
 <ul>
-  <li>President: <a href="https://sites.google.com/view/pedrobrunialti/home">Pedro Brunialti Lima de Andrade</a></li>
-  <li>Vice President: <a href="https://alejandrodlpc.github.io/">Alejandro de las Peñas Castaño</a></li>
+  <li>President: <a href="https://pbrunialti.github.io/">Pedro Brunialti Lima de Andrade</a></li>
+  <li>Vice President: <a href="https://math.virginia.edu/people/ftq4mr/">Astrid Lilly</a></li>
   <li>Secretary: <a href="https://sites.google.com/view/raulhdz">Raúl Hernández-González</a></li>
-  <li>Treasurer: <a href="https://math.virginia.edu/people/guc8ns/">Petch Chueluecha</a></li>
-  <li>Member At Large: <a href="https://math.virginia.edu/people/ntr2qp/">Oscar Arévalo</a></li>
+  <li>Treasurer: <a href="https://awnathan1893.github.io/">Aaratrick Basu</a></li>
+  <li>Member At Large: <a href="https://math.virginia.edu/people/frj5jd/">Vadim Leshkov</a></li>
 </ul>
 Fellow AMS graduate student chapters are most welcome and encouraged to get in touch with us for joint social events!
 


### PR DESCRIPTION
Updated the AMS grad chapter to show the new VP, treasurer and member at large (Astrid, Aaratrick and Vadim, respectively), as well as update their websites.